### PR TITLE
cm: Remove duplicate SEPolicy items

### DIFF
--- a/sepolicy/system.te
+++ b/sepolicy/system.te
@@ -1,5 +1,4 @@
 allow system_server wallpaper_file:file relabelto;
-allow system_server dalvikcache_data_file:file write;
 
 # allow adb related properties to be set
 allow system_server adbtcp_prop:property_service set;
@@ -12,6 +11,3 @@ allow system_server theme_data_file:dir create_dir_perms;
 allow system_server theme_data_file:file create_file_perms;
 allow system_server resourcecache_data_file:dir create_dir_perms;
 allow system_server resourcecache_data_file:file create_file_perms;
-
-# System server dynamically loads some dexfiles
-allow system_server dex2oat_exec:file rx_file_perms;


### PR DESCRIPTION
 * These are handled by the master SEPolicy now due to neverallow
   exceptions which occur on non-production builds.

Change-Id: Id50d9e41e1c8b0b1f26df7921def9e7a201f49d9