### PR TITLE
Update example backup-transport resource overlay

### DIFF
--- a/overlay/common/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/overlay/common/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -17,7 +17,7 @@
  */
 -->
 <resources>
-    <string name="def_backup_transport">com.google.android.backup/.BackupTransportService</string>
+    <string name="def_backup_transport">com.google.android.gms/.backup.BackupTransportService</string>
 
     <!-- Enable notification counters in statusbar -->
     <integer name="def_notif_count">1</integer>


### PR DESCRIPTION
Make sure that the example overlay for configuring a product's
default-active backup transport names the latest incarnation.

Change-Id: I867062f703d3b5f39d40736805ba15f0d21b1afd