### PR TITLE
sepolicy: Make superuser_device and sudaemon mlstrustedobjects

### DIFF
--- a/sepolicy/su.te
+++ b/sepolicy/su.te
@@ -1,9 +1,11 @@
-type superuser_device, file_type;
+type superuser_device, file_type, mlstrustedobject;
 
 ## Perms for the daemon
 
 userdebug_or_eng(`
   domain_trans(init, su_exec, sudaemon)
+
+  typeattribute sudaemon domain, mlstrustedsubject;
 
   type_transition sudaemon socket_device:sock_file superuser_device;
   # The userspace app uses /dev sockets to control per-app access


### PR DESCRIPTION
Address:
avc: denied { write } for pid=8782 comm="su" name="su-daemon" dev="tmpfs" ino=9462
scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:object_r:superuser_device:s0
tclass=sock_file permissive=0

avc: denied { connectto } for pid=6666 comm="su" path="/dev/socket/su-daemon/su-daemon"
scontext=u:r:untrusted_app:s0:c512,c768 tcontext=u:r:sudaemon:s0
tclass=unix_stream_socket permissive=0

And thus fix su.

Change-Id: I666277067c5ff9f2a985c243075c63fd87090b27