### PR TITLE
sepolicy: add persist_block_device type

### DIFF
--- a/sepolicy/qcom/device.te
+++ b/sepolicy/qcom/device.te
@@ -1,0 +1,1 @@
+type persist_block_device, dev_type;


### PR DESCRIPTION
* This is likely defined in several device trees, but not all
  remove it from your device trees if we're going to write rules
  for it here.

Change-Id: I1dda04647d36db52525a3d57b485860dfe3eeb30