### PR TITLE
build: qcom_target: Enable BOARD_USES_ADRENO

### DIFF
--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -27,6 +27,8 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
     qcom_flags += -DQCOM_BSP
     qcom_flags += -DQTI_BSP
 
+    BOARD_USES_ADRENO := true
+
     TARGET_USES_QCOM_BSP := true
 
     # Tell HALs that we're compiling an AOSP build with an in-line kernel


### PR DESCRIPTION
Newer QCOM HALs use this flag for libc2dcolorconvert,
examples being msm8937 and msm8996 media HALs.

Change-Id: I28e8a42b58b4f5f71126df7ad97c377724da5bab