### PR TITLE
config: common: Remove obsolete RomManager props

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -32,14 +32,6 @@ PRODUCT_BOOTANIMATION := vendor/cm/prebuilt/common/bootanimation/$(TARGET_BOOTAN
 endif
 endif
 
-ifdef CM_NIGHTLY
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.rommanager.developerid=cyanogenmodnightly
-else
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.rommanager.developerid=cyanogenmod
-endif
-
 PRODUCT_BUILD_PROP_OVERRIDES += BUILD_UTC_DATE=0
 
 ifeq ($(PRODUCT_GMS_CLIENTID_BASE),)


### PR DESCRIPTION
RomManager hasn't been properly updated in years.
Is this still even a reliable ROM updater anymore?

Change-Id: I3ea57ec0121e6d6f933dd80031bb53514a44e362